### PR TITLE
Remove coveralls

### DIFF
--- a/octoparts.gemspec
+++ b/octoparts.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "vcr"
-  spec.add_development_dependency "coveralls"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,3 @@
-require 'coveralls'
-Coveralls.wear!
-
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'octoparts'
 


### PR DESCRIPTION
We've not used Coveralls. It makes noisy errors on CI like the following: 

```
[Coveralls] Submitting to https://coveralls.io/api/v1
Coveralls encountered an exception:
OpenSSL::SSL::SSLError
```