### PR TITLE
Update represented to 3.1

### DIFF
--- a/lib/octoparts/representer/aggregate_request_representer.rb
+++ b/lib/octoparts/representer/aggregate_request_representer.rb
@@ -8,8 +8,10 @@ module Octoparts
         @camelcase = camelcase
       end
 
-      def call(_represented, args)
-        args.fetch(:user_options, {})[:camelize] ? @camelcase : @camelcase.underscore
+      def call(represented)
+        options = represented.fetch(:options, {})
+        user_options = options.fetch(:user_options, {})
+        user_options[:camelize] ? @camelcase : @camelcase.underscore
       end
     end
 

--- a/octoparts.gemspec
+++ b/octoparts.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '> 2.2'
-  spec.add_dependency "representable", "~> 3.0.0"
+  spec.add_dependency "representable", "~> 3.1.0"
   spec.add_dependency "activesupport", "> 4.0.0"
   spec.add_dependency "faraday"
   spec.add_dependency "multi_json"


### PR DESCRIPTION
`represented 3.1` only passes only 1 argument to `as` proc.